### PR TITLE
style: remove trailing whitespace from base.py

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -7,30 +7,28 @@ from typing import Dict, List, Optional, Set
 
 class ModFramework:
     """Base class for the game modding framework.
-    
+
     Provides core functionality for managing memory modifications, asset dependencies,
     and security validation in game modding operations.
     """
-    
+
     def __init__(self) -> None:
         """Initialize the modding framework with empty tracking structures."""
         self._memory_regions: Set[int] = set()  # Track modified memory regions
         self._hooks: Dict[int, bytes] = {}  # Track active hooks
         self._assets: Dict[str, List[str]] = {}  # Track asset dependencies
-        
     def validate_memory_region(self, address: int, size: int) -> bool:
         """Validate if a memory region is safe to modify.
-        
+
         Args:
             address: Starting address of memory region
             size: Size of region in bytes
-            
+
         Returns:
             bool: True if region is safe to modify, False otherwise
         """
         # Implementation will check for overlaps and validate memory safety
         raise NotImplementedError
-        
     def register_hook(self, address: int, original_bytes: bytes) -> bool:
         """Register a new hook at the specified address.
         


### PR DESCRIPTION
Clean up trailing whitespace in ModFramework class docstrings and method docstrings to improve code style and readability.