### PR TITLE
Fix: Add lock to prevent race condition in memory validation

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -5,6 +5,7 @@ safe game modifications with memory integrity checks.
 """
 
 from typing import Dict, List, Optional, Set, Tuple
+import threading
 
 
 class ModFramework:
@@ -28,6 +29,7 @@ class ModFramework:
         self._memory_regions: Set[int] = set()
         self._hooks: Dict[int, bytes] = {}
         self._assets: Dict[str, List[str]] = {}
+        self._lock = threading.Lock()
 
     def validate_memory_region(self, address: int, size: int) -> Tuple[bool, Optional[str]]:
         """Validate if a memory region is safe to modify.
@@ -48,18 +50,23 @@ class ModFramework:
             raise ValueError("Memory address cannot be negative")
         if size <= 0:
             raise ValueError("Memory region size must be positive")
-        # Check if the new region overlaps with any existing regions
-        end_address = address + size
         
-        for region_start in self._memory_regions:
-            # Assume each region is 1 page (4096 bytes) for basic implementation
-            region_end = region_start + 4096
+        with self._lock:
+            # Check if the new region overlaps with any existing regions
+            end_address = address + size
             
-            # Check for overlap: new region starts before existing ends and ends after existing starts
-            if address < region_end and end_address > region_start:
-                return False, f"Region overlaps with existing region at 0x{region_start:x}"
+            for region_start in self._memory_regions:
+                # Assume each region is 1 page (4096 bytes) for basic implementation
+                region_end = region_start + 4096
                 
-        return True, None
+                # Check for overlap: new region starts before existing ends and ends after existing starts
+                if address < region_end and end_address > region_start:
+                    return False, f"Region overlaps with existing region at 0x{region_start:x}"
+
+            # If no overlap, add the new region to the set
+            self._memory_regions.add(address)
+
+            return True, None
 
     def register_hook(self, address: int, original_bytes: bytes) -> bool:
         """Register a new hook at the specified address.

--- a/tests/integration/test_memory_concurrency.py
+++ b/tests/integration/test_memory_concurrency.py
@@ -16,14 +16,14 @@ def test_concurrent_memory_validation():
     validator = SecurityValidator()
     
     # Test addresses and data
-    addresses = [0x1000, 0x2000, 0x3000, 0x4000]
+    addresses = [0x1000, 0x1010, 0x1020, 0x1030]  # These addresses are within the same 4k page
     test_data = b"test data"
     results = []
     
     def validate_region(address):
         """Validate memory region in a thread."""
         # Validate memory region
-        is_valid = framework.validate_memory_region(address, len(test_data))
+        is_valid, _ = framework.validate_memory_region(address, len(test_data))
         # Validate modification if region is valid
         if is_valid:
             success, _ = validator.validate_modification(address, test_data)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -10,43 +10,68 @@ def test_mod_framework_initialization():
     assert len(framework._memory_regions) == 0
     assert len(framework._hooks) == 0
     assert len(framework._assets) == 0
+    assert framework._lock is not None
 
 
-def test_validate_memory_region():
-    """Test memory region validation."""
+def test_validate_memory_region_success():
+    """Test successful memory region validation for non-overlapping regions."""
     framework = ModFramework()
-    
-    # Test non-overlapping regions
     is_valid, error = framework.validate_memory_region(0x1000, 16)
-    assert is_valid and error is None
-    
-    is_valid, error = framework.validate_memory_region(0x2000, 16)
-    assert is_valid and error is None
-    
-    # Test invalid inputs
+    assert is_valid is True
+    assert error is None
+    assert 0x1000 in framework._memory_regions
+
+
+def test_validate_memory_region_invalid_inputs():
+    """Test memory region validation with invalid inputs."""
+    framework = ModFramework()
     with pytest.raises(ValueError, match="Memory address cannot be negative"):
         framework.validate_memory_region(-1, 16)
-    
     with pytest.raises(ValueError, match="Memory region size must be positive"):
         framework.validate_memory_region(0x1000, 0)
+
+
+def test_validate_memory_region_overlap():
+    """Test that overlapping memory regions are correctly detected."""
+    framework = ModFramework()
+    # Add a region
+    is_valid, error = framework.validate_memory_region(0x3000, 16)
+    assert is_valid is True
     
-    # Add a region and test overlap
-    framework._memory_regions.add(0x3000)
-    
-    # Test overlap with existing region (4096 byte pages)
+    # Test overlap with the existing region
     is_valid, error = framework.validate_memory_region(0x3100, 16)  # Inside page
-    assert not is_valid
+    assert is_valid is False
     assert error is not None and "overlaps with existing region" in error
-    
-    is_valid, error = framework.validate_memory_region(0x4000, 16)  # Next page
-    assert is_valid and error is None
-    
-    # Test boundary conditions
-    is_valid, error = framework.validate_memory_region(0x2F00, 16)  # Just before
-    assert is_valid and error is None
-    
-    is_valid, error = framework.validate_memory_region(0x3FF0, 16)  # Just inside
-    assert not is_valid
+
+
+def test_validate_memory_region_no_overlap_adjacent():
+    """Test that adjacent but non-overlapping regions are considered valid."""
+    framework = ModFramework()
+    # Add a region
+    is_valid, error = framework.validate_memory_region(0x3000, 4096) # Assume page size
+    assert is_valid is True
+
+    # Test next page, which should not overlap
+    is_valid, error = framework.validate_memory_region(0x4000, 16)
+    assert is_valid is True
+    assert error is None
+
+
+def test_validate_memory_region_boundary_conditions():
+    """Test boundary conditions for memory region validation."""
+    framework = ModFramework()
+    # Add a region at 0x3000
+    framework.validate_memory_region(0x3000, 16)
+
+    # Test just before the page boundary
+    is_valid, error = framework.validate_memory_region(0x2000, 16)
+    assert is_valid is True
+    assert error is None
+
+    # Test just inside the page boundary of the existing region
+    # Existing region starts at 0x3000, page ends at 0x3000 + 4096 = 0x3FFF
+    is_valid, error = framework.validate_memory_region(0x3FF0, 16)
+    assert is_valid is False
     assert error is not None and "overlaps with existing region" in error
 
 
@@ -76,11 +101,8 @@ def test_memory_region_tracking():
     framework = ModFramework()
     
     # Validate and track regions
-    assert framework.validate_memory_region(0x1000, 16)
-    framework._memory_regions.add(0x1000)
-    
-    assert framework.validate_memory_region(0x2000, 16)
-    framework._memory_regions.add(0x2000)
+    framework.validate_memory_region(0x1000, 16)
+    framework.validate_memory_region(0x2000, 16)
     
     # Verify tracking
     assert 0x1000 in framework._memory_regions


### PR DESCRIPTION
If multiple threads call validate_memory_region concurrently, a race condition occurs. Fix: Add a lock to ensure the check for region overlap and the subsequent update to the shared region set are performed as a single atomic operation.