### PR TITLE
fix(concurrency): Raise KeyError for non-existent region release

### DIFF
--- a/src/concurrency/atomic.py
+++ b/src/concurrency/atomic.py
@@ -92,12 +92,12 @@ class AtomicModifier:
 
         Args:
             address: Start address of region to release
+
+        Raises:
+            KeyError: If the address is not an active region.
         """
         with self._global_lock:
-            regions = [hex(addr) for addr in self._active_regions.keys()]
-            print(f"\nBefore release - Active regions: {regions}")
-            if address in self._region_locks:
-                del self._region_locks[address]
-                del self._active_regions[address]
-            regions = [hex(addr) for addr in self._active_regions.keys()]
-            print(f"After release - Active regions: {regions}\n")
+            if address not in self._active_regions:
+                raise KeyError(f"Address {hex(address)} is not an active region.")
+            del self._region_locks[address]
+            del self._active_regions[address]

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -1,5 +1,5 @@
 """Unit tests for concurrency control and atomic operations."""
-
+import pytest
 from src.concurrency.atomic import AtomicModifier
 
 
@@ -58,3 +58,11 @@ def test_ensure_thread_safety():
     modifier.release_region(0x1000)
     # Try to lock a region that doesn't overlap with 0x2000-0x3000
     assert modifier.ensure_thread_safety(0x1000, 4096) is True
+
+
+def test_release_non_existent_region():
+    """Test that releasing a non-existent region raises an error."""
+    modifier = AtomicModifier()
+    modifier.ensure_thread_safety(0x1000, 100)
+    with pytest.raises(KeyError, match="Address 0x2000 is not an active region."):
+        modifier.release_region(0x2000)


### PR DESCRIPTION
The `release_region` method in `AtomicModifier` now raises a `KeyError` if an attempt is made to release a memory region that is not currently locked. Previously, this operation would fail silently, which could mask bugs in the calling code.

A new test case has been added to verify that a `KeyError` is raised when releasing a non-existent region.